### PR TITLE
Remove compatibility to middlewares/http-authentication 2.1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "typo3/cms-core": "^9.5 || ^10.4",
         "typo3/cms-backend": "^9.5 || ^10.4",
-        "middlewares/http-authentication": "^1.1 || ^2.1"
+        "middlewares/http-authentication": "^1.1"
     },
     "require-dev": {
         "extrameile/grumphp-conventions-typo3": "dev-master"


### PR DESCRIPTION
At the moment this leads to an issue with PSR-17/guzzle and the virtual-package psr/http-factory-implementation